### PR TITLE
In some locales, the decimal separators is a comma

### DIFF
--- a/main.go
+++ b/main.go
@@ -1321,8 +1321,8 @@ func getProcessList() []ProcessMetrics {
 		if len(fields) < 11 {
 			continue
 		}
-		cpu, _ := strconv.ParseFloat(fields[2], 64)
-		mem, _ := strconv.ParseFloat(fields[3], 64)
+		cpu, _ := strconv.ParseFloat(replaceCommas(fields[2]), 64)
+		mem, _ := strconv.ParseFloat(replaceCommas(fields[3]), 64)
 		vsz, _ := strconv.ParseInt(fields[4], 10, 64)
 		rss, _ := strconv.ParseInt(fields[5], 10, 64)
 		pid, _ := strconv.Atoi(fields[1])
@@ -1335,6 +1335,10 @@ func getProcessList() []ProcessMetrics {
 		return processes[i].CPU > processes[j].CPU
 	})
 	return processes
+}
+
+func replaceCommas(s string) string {
+	return strings.Replace(s, ",", ".", -1)
 }
 
 func updateTotalPowerChart(watts float64) {


### PR DESCRIPTION
It seems that the `ps` command respects locale settings and uses different decimal separators depending on the locale. For example, the Ukrainian (uk) locale uses a comma as the decimal separator instead of a period so CPU and MEM usage numbers are shown as `12,4`. As a result, `strconv.ParseFloat` fails to parse floating-point numbers in the following lines of the getProcessList() function:

```
cpu, _ := strconv.ParseFloat(fields[2], 64)
mem, _ := strconv.ParseFloat(fields[3], 64)

```

A more universal solution could involve checking the current locale, determining the decimal separator, or using a third-party module. However, in practice, there are only two common cases: a comma or a period. For this specific use case, simply replacing the comma with a period before parsing should be sufficient.

BTW `powermetrics -s tasks` didn't respect locale settings and used period as decimal separator. 

Fixes #47 